### PR TITLE
migrate to envoy-gateway, Gateway API

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,7 @@ repos:
     rev: v0.19.0
     hooks:
       - id: yamlfmt
+        exclude: "charts/.*/templates/.*"
   # Misc autoformatting and linting
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/charts/hub/values.yaml
+++ b/charts/hub/values.yaml
@@ -6,12 +6,11 @@ jupyterhub:
       nodeSelector: *coreNodeSelector
     service:
       type: ClusterIP
-  ingress:
+  httpRoute:
     enabled: true
-    ingressClassName: traefik
-    annotations:
-      ingress.kubernetes.io/proxy-body-size: 64m
-      kubernetes.io/tls-acme: "true"
+    gateway:
+      name: default
+      namespace: support
   singleuser:
     events: true
     image:

--- a/charts/support/Chart.lock
+++ b/charts/support/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
-- name: traefik
-  repository: oci://ghcr.io/traefik/helm
-  version: 37.3.0
+- name: gateway-helm
+  repository: oci://docker.io/envoyproxy
+  version: v1.6.2
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
   version: 27.36.0
 - name: grafana
   repository: https://grafana.github.io/helm-charts
   version: 9.4.4
-digest: sha256:5094d54c16db4ac9e137f08c09beba64d795ef9204750bf0702f72630d99bcee
-generated: "2025-11-13T13:03:08.448858-08:00"
+digest: sha256:46c838cb3dd725f56d1e76db31a38805116bb69329e8c29273416e08361a6cac
+generated: "2026-01-20T07:42:37.363889-08:00"

--- a/charts/support/Chart.yaml
+++ b/charts/support/Chart.yaml
@@ -4,9 +4,9 @@ name: support
 version: "0.0.0"
 kubeVersion: ">= 1.32.0-0"
 dependencies:
-  - name: traefik
-    version: "37.3.0"
-    repository: oci://ghcr.io/traefik/helm
+  - name: gateway-helm
+    version: v1.6.2
+    repository: oci://docker.io/envoyproxy
   - name: prometheus
     version: "27.36.0"
     repository: https://prometheus-community.github.io/helm-charts

--- a/charts/support/templates/cluster-issuer.yaml
+++ b/charts/support/templates/cluster-issuer.yaml
@@ -1,0 +1,38 @@
+{{ if .Values.clusterIssuer.enabled }}
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: minrk@berkeley.edu
+    privateKeySecretRef:
+      name: letsencrypt-staging
+    solvers:
+      - http01:
+          gatewayHTTPRoute:
+            parentRefs:
+              - name: default
+                namespace: support
+                kind: Gateway
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: minrk@berkeley.edu
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    solvers:
+      - http01:
+          gatewayHTTPRoute:
+            parentRefs:
+              - name: default
+                namespace: support
+                kind: Gateway
+{{- end }}

--- a/charts/support/templates/gateway-config.yaml
+++ b/charts/support/templates/gateway-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: default-proxy-config
+spec:
+  {{- with .Values.gateway.config }}
+  {{ . | toYaml | nindent 2 }}
+  {{- end }}

--- a/charts/support/templates/gateway.yaml
+++ b/charts/support/templates/gateway.yaml
@@ -1,0 +1,35 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: default
+  annotations:
+    cert-manager.io/cluster-issuer: {{ .Values.gateway.issuerName }}
+spec:
+  gatewayClassName: eg
+  infrastructure:
+      parametersRef:
+        group: gateway.envoyproxy.io
+        kind: EnvoyProxy
+        name: default-proxy-config
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+    # need one listener per hostname.
+    # gateway doesn't need this,
+    # but cert-manager gateway support does
+    # listenerSets might help
+    # ref: https://github.com/cert-manager/cert-manager/issues/6051
+    {{- range .Values.gateway.hostnames }}
+    - name: https-{{ . }}
+      protocol: HTTPS
+      port: 443
+      allowedRoutes:
+        namespaces:
+          from: All
+      hostname: {{ . | quote }}
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: default-gateway-{{ . }}
+    {{- end }}

--- a/charts/support/templates/gatewayclass.yaml
+++ b/charts/support/templates/gatewayclass.yaml
@@ -1,0 +1,6 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: eg
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/charts/support/values.yaml
+++ b/charts/support/values.yaml
@@ -1,5 +1,17 @@
 coreNodeSelector: &coreNodeSelector
   hub.jupyter.org/node-purpose: core
+gateway:
+  issuerName: letsencrypt-prod
+  # need to specify each hostname individually on the gateway
+  # for cert-manager
+  hostnames: []
+  config:
+    # passthrough for EnvoyProxy config
+    # https://gateway.envoyproxy.io/docs/tasks/operations/customize-envoyproxy/
+    provider:
+      type: Kubernetes
+clusterIssuer:
+  enabled: true
 grafana:
   nodeSelector: *coreNodeSelector
   grafana.ini:
@@ -9,11 +21,12 @@ grafana:
       org_role: Viewer
     auth.basic:
       enabled: true
-  ingress:
-    enabled: true
-    ingressClassName: traefik
-    annotations:
-      kubernetes.io/tls-acme: "true"
+  route:
+    main:
+      enabled: true
+      parentRefs:
+        - name: default
+          namespace: support
   persistence:
     size: 2Gi
     enabled: true
@@ -34,29 +47,13 @@ prometheus:
     nodeSelector: *coreNodeSelector
     podLabels:
       hub.jupyter.org/network-access-hub: "true"
-    ingress:
-      enabled: true
-      ingressClassName: traefik
-      annotations:
-        kubernetes.io/tls-acme: "true"
+    route:
+      main:
+        enabled: true
+        parentRefs:
+          - name: default
+            namespace: support
   kube-state-metrics:
     metricLabelsAllowlist:
       - pods=[app,component]
       - nodes=[*]
-traefik:
-  providers:
-    kubernetesCRD:
-      enabled: false
-  service:
-    spec:
-      # Preserve client IPs
-      externalTrafficPolicy: Local
-  ingressClass:
-    name: traefik
-    isDefaultClass: true
-  nodeSelector: *coreNodeSelector
-  deployment:
-    replicas: 2
-  logs:
-    access:
-      enabled: true

--- a/clusters/demo/support/config.yaml
+++ b/clusters/demo/support/config.yaml
@@ -1,5 +1,20 @@
 coreNodeSelector: &coreNodeSelector
   hub.jupyter.org/node-purpose: core
+gateway:
+  # need to specify each hostname individually on the gateway
+  # for cert-manager
+  hostnames:
+    - aifutureslab-hub-grafana.bids.berkeley.edu
+    - aifutureslab-hub-prometheus.bids.berkeley.edu
+    - aifutureslab-hub.bids.berkeley.edu
+  config:
+    provider:
+      kubernetes:
+        envoyService:
+          annotations:
+            # preserve ip when gateway service gets recreated
+            cloud.google.com/l4-rbs: "enabled"
+            networking.gke.io/load-balancer-ip-addresses: "demo-ingress"
 grafana:
   nodeSelector: *coreNodeSelector
   grafana.ini:
@@ -9,13 +24,10 @@ grafana:
       org_role: Viewer
     auth.basic:
       enabled: true
-  ingress:
-    hosts:
-      - aifutureslab-hub-grafana.bids.berkeley.edu
-    tls:
-      - hosts:
-          - aifutureslab-hub-grafana.bids.berkeley.edu
-        secretName: tls-grafana
+  route:
+    main:
+      hostnames:
+        - aifutureslab-hub-grafana.bids.berkeley.edu
   datasources:
     datasources.yaml:
       apiVersion: 1
@@ -28,16 +40,7 @@ grafana:
           editable: false
 prometheus:
   server:
-    ingress:
-      hosts:
-        - aifutureslab-hub-prometheus.bids.berkeley.edu
-      tls:
-        - hosts:
-            - aifutureslab-hub-prometheus.bids.berkeley.edu
-          secretName: tls-prometheus
-traefik:
-  service:
-    annotations:
-      # use the reserved ip for ingress
-      cloud.google.com/l4-rbs: "enabled"
-      networking.gke.io/load-balancer-ip-addresses: "demo-ingress"
+    route:
+      main:
+        hostnames:
+          - aifutureslab-hub-prometheus.bids.berkeley.edu

--- a/hubs/demo/config.yaml
+++ b/hubs/demo/config.yaml
@@ -1,4 +1,7 @@
 jupyterhub:
+  httpRoute:
+    hostnames:
+      - aifutureslab-hub.bids.berkeley.edu
   hub:
     config:
       JupyterHub:
@@ -36,13 +39,6 @@ jupyterhub:
           return '/hub/spawn'
 
         c.JupyterHub.default_url = default_url
-  ingress:
-    hosts:
-      - aifutureslab-hub.bids.berkeley.edu
-    tls:
-      - secretName: tls-jupyterhub
-        hosts:
-          - aifutureslab-hub.bids.berkeley.edu
 jupyterhub-home-nfs:
   prometheusExporter:
     enabled: true

--- a/noxfile.py
+++ b/noxfile.py
@@ -76,7 +76,7 @@ def helm_support_upgrade_crds(session):
     decrypt(session)
     set_kubeconfig(cluster_name)
     session.run("helm", "dependency", "update", SUPPORT_CHART, external=True)
-    # apply any CRD upgrades (e.g. cert-manager)
+    # apply any CRD upgrades (e.g. cert-manager, envoy gateway)
     # helm cannot upgrade CRDs
     # from https://github.com/traefik/traefik-helm-chart?tab=readme-ov-file#upgrade-the-standalone-traefik-chart
     with NamedTemporaryFile() as f:

--- a/tf/modules/gke_cluster/resource.tf
+++ b/tf/modules/gke_cluster/resource.tf
@@ -214,47 +214,26 @@ resource "helm_release" "cert-manager" {
   repository = "https://charts.jetstack.io"
   chart      = "cert-manager"
   version    = "v1.19.1"
-  set = [{
-    name  = "crds.enabled"
-    value = "true"
+  set = [
+    {
+      name  = "crds.enabled"
+      value = "true"
     },
     {
-      name  = "ingressShim.defaultIssuerName"
-      value = "letsencrypt-prod"
+      name  = "config.apiVersion"
+      value = "controller.config.cert-manager.io/v1alpha1"
+    },
+    {
+      name  = "config.kind"
+      value = "ControllerConfiguration"
+    },
+    {
+      name  = "config.enableGatewayAPI"
+      value = "true"
     },
     {
       name  = "ingressShim.defaultIssuerKind"
       value = "ClusterIssuer"
-  }]
-}
-
-resource "kubernetes_manifest" "cluster_issuer" {
-  for_each = toset(["staging", "prod"])
-
-  manifest = {
-    apiVersion = "cert-manager.io/v1"
-    kind       = "ClusterIssuer"
-    metadata = {
-      name = "letsencrypt-${each.key}"
     }
-    spec = {
-      acme = {
-        server = "https://acme${each.key == "staging" ? "-staging" : ""}-v02.api.letsencrypt.org/directory"
-        email  = "minrk@berkeley.edu"
-        privateKeySecretRef = {
-          name = "letsencrypt-${each.key}"
-        }
-        solvers = [{
-          http01 = {
-            ingress = {
-              class = "traefik"
-            }
-          }
-          }
-        ]
-      }
-    }
-  }
-
-  depends_on = [helm_release.cert-manager]
+  ]
 }


### PR DESCRIPTION
Removed:

- traefik
- ingress config

Added:
- define default GatewayClass
- define EnvoyProxy config so we can apply service annotations for static IP
- define default Gateway with each hostname as a listener (needed for cert-issuer)

Changed:
- switch letsencrypt cluster-issuers to use http01 Gateway solver
- enable gateway support in cert-manager
- replace ingress configs with httpRoutes (all charts support these already)

not exactly related to the PR, but in updating the cert-issuers, I decided to move them from the terraform deploy to the support chart.
I think I may move `cert-manager` into the support chart as well so everything's consistently in helm, but there could be ordering issues there.
