### PR TITLE
switch to cilogon

### DIFF
--- a/hubs/demo/config.enc.yaml
+++ b/hubs/demo/config.enc.yaml
@@ -6,12 +6,38 @@ jupyterhub:
       CryptKeeper:
         keys:
           - ENC[AES256_GCM,data:kRIUiGWtSwFc1oida/wN6vOFAtteq5LlZm1fydFJ+50nl7NVPo/BkGnveD6jk99Z0tNqZ8crv9/HPiNcP5n45g==,iv:ajq1CeD9Ob8fUq1pNz23Ttfyq2Pm7ltXbhV2AsXb5MI=,tag:LtxHw9QRmNl1OWWeidIfEA==,type:str]
+      CILogonOAuthenticator:
+        client_id: ENC[AES256_GCM,data:+65MkJswc/I4Y+0iWITIv1bjOmkZ2TxSMvAFNUG9OSnOasfgG27EJ3Cx1BBGO+d721VQ,iv:+Xb1247YUAYu+A+1YJKLTQm2ZV9L1F7sXxbaJZ3XUR8=,tag:pwq+niwkYjYODsurEnrjgg==,type:str]
+        client_secret: ENC[AES256_GCM,data:Oj14IsiufB667hd6fE8QtbQTj0wZLgXfTymM1Qo8VGGtWRDOW5BUHYyrmzLF9dsbcC0VfpVJ9Jvolp0N92Mfkyu/XFxLeL8Xj67e0uqzXGlKYsMRmbA=,iv:Mt5i1HFU2GwuCTvj//SsK8k21PFPWR3GNj3aKVt6Phw=,tag:Bv3OkNnHmMTA5mAQtHVfsA==,type:str]
       GenericOAuthenticator:
         client_id: ENC[AES256_GCM,data:sQY2guMIon2ImMYYTcFbbO8=,iv:7+haGUXHfAT82tKJRw/lWvnd4gCnSBnT7DsnvTxEPTg=,tag:KeEMTRbapUBi8fso6tQYNw==,type:str]
         client_secret: ENC[AES256_GCM,data:i9x/SLwQ3nELqXvUEb4NA5Yqp0FuG0rcB48/U/gyYSpior97R47t3DKvFXSEyErp,iv:8VSlBTRy957gsqlnpsRDdb3F3lhqdyYWuqqQnoY5oms=,tag:CqsIBEQkf2aa1X4mFueNGg==,type:str]
       GitHubOAuthenticator:
         client_id: ENC[AES256_GCM,data:mKvNAh5T429/jernGiL8q9irOwY=,iv:ST1wDIfMdpGoruFtCQ6LrI1hQL5pRcjGimy7Tk5VEXs=,tag:pbQOB19ZD4Bl2qYgF3sfIA==,type:str]
         client_secret: ENC[AES256_GCM,data:CPWV4OXv18U0Ib+AWWiAwLuimj/UXqei2L7hbKbntKiFM+k+NGYonA==,iv:VdMdhHz7lZlfg6Mwl1BIk03qqtbApq1By5F5n+b4Hbs=,tag:XjDJV2rA5HzofAlzwpTCsQ==,type:str]
+    extraFiles:
+      access:
+        data:
+          admin_users:
+            - ENC[AES256_GCM,data:khanoQ4+8ks1qT15OFfsBFXz,iv:Wt01C09tNlHZoT46qlWF3E/peOa7rCG0IV2Q1Noxl3A=,tag:NeTxW4WGEx3DvPILSJOYtg==,type:str]
+            - ENC[AES256_GCM,data:aCLptEOAdFFVGKgFm96ZwJZK8Wgzst0tup2OrmBj,iv:yZW4smFv8JkR88HTdkfQLB/nU3Jnt+k8O2C0BwXSJZE=,tag:LDbccYgT6twxiZ8HHHcyIw==,type:str]
+            - ENC[AES256_GCM,data:wkQ6i23qmYFmlpDP6leqbQdnCeoRAfk7zhhy,iv:DQB6u99YLBMbzNIp+ORgvWbLnDGxDeaVaBvEoFcH2G0=,tag:WBqyq5Jawty0ze6Y0h5aLg==,type:str]
+          allowed_users:
+            - ENC[AES256_GCM,data:N9qjjLOogPepZYzDybZGJIkparjFKRC6RRrljqM=,iv:nH7pDtP2cnIXfWkRIkhETnSU8yy6MixgSZH4iESAgqA=,tag:Ez1MHYHJ5dCBVcv47RqtUw==,type:comment]
+            - ENC[AES256_GCM,data:AMwDzsi8qQc8/k+Al0Bj0HDYwlzz1yiQoclwfJlSw4oc6cE6R5weKn4E,iv:Nvq/BPTJzj9zx2fvmnwBBOkVQO7t7rda++2Qku2r9WI=,tag:P3EkxQ2FstRF94SuBRNskA==,type:comment]
+            - ENC[AES256_GCM,data:Z5mFBiynttFiRkkRxmHuCJVesInPczaCoow=,iv:i/AxRtH0o52k7V4QWN40LJ11ZHeRj2pRMSz98oKJOjk=,tag:xrVIXJnoVM4f8hrRX5IGxQ==,type:comment]
+            - ENC[AES256_GCM,data:ARbrjhtj5e4rCMo/SWHnTnZO,iv:KTxhflB8MrUbOTx+UdgysZSo+Vuen2vbKijD097Fy7c=,tag:RsD4a/Y+KyzYiM7gTPcB4A==,type:str]
+            - ENC[AES256_GCM,data:UfQu+yoRgnDRWYAdAJfMDtIx9wQ=,iv:meMptDnXRJij2/JkrgetKLUqe76xbYlglmbB/JZmDp8=,tag:Y/eYTGQ4Z3n0aCxPdUBoDQ==,type:str]
+          collaborations:
+            bids-comms:
+              - ENC[AES256_GCM,data:ePoZPk+DGnphZaWOBU6WDwk2BQOURzDPOsafJ/sC,iv:uCXGlvUCwrBGxi392dhxWWaZ3lpAvsGhc2jt6kc8rlQ=,tag:BwHgbClGfMnPgDRYjZ0IKw==,type:str]
+              - ENC[AES256_GCM,data:ykWzCJN6auJ1rfgBhUPpKbup,iv:swPGzMHYrxb/mlgL4j2xowEmLSQaPLlIW5On9xM5V8w=,tag:UiXEZbeZQ/lFSafS6ZXkKw==,type:str]
+              - ENC[AES256_GCM,data:LNZu4wnWkwM5ok+eN/o22dSV,iv:nTSjf4xk18n2ePQX2hz+sAfGPJ0GDPHYEUqfPQe7zPg=,tag:l/tAW6DGFJ2vrFj7VwCZzQ==,type:str]
+              - ENC[AES256_GCM,data:J+ctk9o5zJyKzbTJoo8Wk0ZQiw==,iv:g89V5pMCIPpLrADVR1keOm7oO7zRazmyW8un8QY2Fxs=,tag:oaaPEDrdrgctcRP4ANCjMA==,type:str]
+              - ENC[AES256_GCM,data:GPbVYKJ2NQrBAMUAH5zUB+C+32PoPebB,iv:vhjqaLmPiQv3RJ0t3sVZTCG1tvjDGxOeXswT81nGuB4=,tag:7Pa4kBM7IpX9UQmtihvsAw==,type:str]
+              - ENC[AES256_GCM,data:sG7B620/NjpiEz2zb38jaJDXZgz7wG2OCg==,iv:tVnRjBXKJBBVnBOZ80FvwYMJ/Wkh/i2E/rj24+Jv5l8=,tag:+lmrmfIdjdntUD3Ukb2pVQ==,type:str]
+              - ENC[AES256_GCM,data:OebxCEcSnlsiYZi5ILr9Hm7TUNb2jOo6cgMd,iv:Pf5ayA8x+APLwzT2tZmJTZYzJKdyOO9apoMaJl6k+yU=,tag:S5BVkwSgeTQdaoT1x1oqCQ==,type:str]
+              - ENC[AES256_GCM,data:Mwak9jB7V3Rqh2YmebJdn1R0BztR,iv:vEwhBqzqkuy7boFnZSfajugTomgZXeocO6YUsl8ddqQ=,tag:UVWT0ytQeRX9R/J87Y49zg==,type:str]
   proxy:
     secretToken: ENC[AES256_GCM,data:3QKrgCSyP6Wr17HB79aoy+VK1RbQhtNujm2dVy59HFsszl210D4Z3auoVcWrM/oMR1T0wRm33feJT96loLTyYio=,iv:A1KgOt0mhNAt6VVN4OMfRcDp7kYq37yn6ji29T+p60M=,tag:rAI3Cp0720E6H1gkmBkVdg==,type:str]
   singleuser:
@@ -22,7 +48,7 @@ sops:
     - created_at: "2025-10-21T23:38:24Z"
       enc: CiQANyKZ8JQe1adKWAUM5Zj4Zevua+ecZ/Yaa7QpDmaXBxll760SSQDUA4fNrJIcn6X07JCvjVXPvk35izob3ftA9ZLIIjYjwoYdBBNEuphU0KWlJFsuLktZMbk5PJKLhmuhZ9zgy3TN9MHsmvUEUsk=
       resource_id: projects/bids-jupyterhub/locations/global/keyRings/sops/cryptoKeys/sops-key
-  lastmodified: "2026-06-18T22:59:59Z"
-  mac: ENC[AES256_GCM,data:yCXTMPYI6YVnB44o8hQxEUhj7WMiDK31N6N95ebxRYwKTrqrBVDVIo4i4I+xiLKP7p/VL3vac5u2RxEzadKYePLqUHo+l0ngL5wAx2PySGbO9ApirCiEW+J+AjGp/+nCz98u7zA2OA3Cpxpc+hS6p7eIimM2DCPklxgkcx8pPoY=,iv:RGm98qFDsKLID8JTgv6axyLOuxOT/c0/tDoE6/hePYg=,tag:I7KfP7Ff2L7wzMl6JIYewQ==,type:str]
+  lastmodified: "2026-06-19T21:07:27Z"
+  mac: ENC[AES256_GCM,data:MhL37e97ELLJwXApqN86fc9h6rThbEXDR4+NCfthQ/D/yOLMNvdkt4oRaeLKfD6oKE7zMZ7IF/FQVmYem8gJCgo1f/Wad2uVxEXcvS/AaqrhGfO3eWn50tXdrZm2O6eVXdDmWcdbnRTU7PhfjMk7acQGvSd4NvQsicvrb2IJopU=,iv:BtxZSfQLC0EXNLQo7SlfdjD4rFn5rlNg5GWXmpDqGjs=,tag:33drtTeCSYGW7i6sQ/p9Dw==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.13.1

--- a/hubs/demo/config.yaml
+++ b/hubs/demo/config.yaml
@@ -7,30 +7,55 @@ jupyterhub:
       Authenticator:
         enable_auth_state: true
       JupyterHub:
-        # authenticator_class: generic-oauth
-        authenticator_class: github
+        authenticator_class: cilogon
+        # authenticator_class: github
         public_url: https://aifutureslab-hub.bids.berkeley.edu
+      OAuthenticator:
+        oauth_callback_url: https://aifutureslab-hub.bids.berkeley.edu/hub/oauth_callback
+      CILogonOAuthenticator:
+        scope:
+          - openid
+          - email
+          - profile
+          - org.cilogon.userinfo
+        idps:
+          urn:mace:incommon:berkeley.edu:
+            default: true
+            username_derivation:
+              username_claim: eppn
+          urn:mace:incommon:ucdavis.edu:
+            username_derivation:
+              username_claim: eppn
+          urn:mace:incommon:ucsf.edu:
+            username_derivation:
+              username_claim: eppn
+          http://github.com/login/oauth/authorize:
+            username_derivation:
+              username_claim: preferred_username
+              action: prefix
+              prefix: github
       GenericOAuthenticator:
+        login_service: CalNet
+        username_claim: sub
+        authorize_url: https://auth.berkeley.edu/cas/oidc/oidcAuthorize
+        token_url: https://auth.berkeley.edu/cas/oidc/oidcAccessToken
+        userdata_url: https://auth.berkeley.edu/cas/oidc/oidcProfile
+        scope:
+          - openid
+          - profile
+          - berkeley_edu_default
+      GenericOAuthenticator_calnet:
         login_service: CalNet
         username_claim: sub
         oauth_callback_url: https://aifutureslab-hub.bids.berkeley.edu/hub/oauth_callback
         authorize_url: https://auth.berkeley.edu/cas/oidc/oidcAuthorize
         token_url: https://auth.berkeley.edu/cas/oidc/oidcAccessToken
         userdata_url: https://auth.berkeley.edu/cas/oidc/oidcProfile
-        allowed_users:
-          # collaboration users must be invalid github usernames
-          - _bids-comms
-        admin_users:
-          - minrk
         scope:
           - openid
           - profile
           - berkeley_edu_default
       GitHubOAuthenticator:
-        oauth_callback_url: https://aifutureslab-hub.bids.berkeley.edu/hub/oauth_callback
-        allowed_users:
-          # collaboration users must be invalid github usernames
-          - _bids-comms
         allowed_organizations:
           - "bids-access:aifutures-hub-users"
         admin_groups:
@@ -40,15 +65,6 @@ jupyterhub:
         scope:
           - "user:email"
           - "read:org"
-    loadRoles:
-      bids-comms:
-        scopes:
-          - admin-ui
-          - "access:servers!user=_bids-comms"
-          - "admin:servers!user=_bids-comms"
-          - "list:users!user=_bids-comms"
-        groups:
-          - bids-comms
     extraConfig:
       team_groups: |
         def access_team_groups(auth_state):
@@ -66,27 +82,37 @@ jupyterhub:
       # mount shared directories for the collaboration groups
       # these are the _home_ directories of the collaboration accounts
       shared_directories: |
-        collaboration_groups = {
-            "bids-comms",
-        }
+        import json
+
+        with open("/etc/jupyterhub/access.json") as f:
+            access = json.load(f)
 
         def mount_collaboration_directories(spawner):
             if not spawner.volume_mounts:
                 spawner.volume_mounts = {}
             for group in spawner.user.groups:
-                if group.name in collaboration_groups:
+                if group.name.endswith("@collaboration"):
+                    name, *_ = group.name.rpartition("@")
                     # mount the user's home in shared/$group
-                    # user (home subPath) = _bids-comms
-                    # group = bids-comms
+                    # user (home subPath) = bids-comms@collaboration
+                    # group = bids-comms@collaboration
                     spawner.volume_mounts[group.name] = {
-                        "mountPath": f"/home/jovyan/shared/{group.name}",
+                        "mountPath": f"/home/jovyan/shared/{name}",
                         "name": "home",
-                        "subPath": "_" + group.name,
+                        "subPath": group.name,
                     }
+            if spawner.user.admin:
+                # admins can manage the shared home directory
+                spawner.volume_mounts["admin-home"] = {
+                    # don't put this in the jupyter root
+                    "mountPath": f"/home/all-home",
+                    "name": "home",
+                }
+
         c.Spawner.pre_spawn_hook = mount_collaboration_directories
       refresh_user: |
         def refresh_user_hook(authenticator, user, auth_state):
-            if user.name.startswith("_"):
+            if user.name.endswith("@collaboration"):
                 # don't require refresh user auth for collaboration and testing accounts
                 # (these aren't github users)
                 return True
@@ -113,7 +139,7 @@ jupyterhub:
             if github_user["email"]:
                 spawner.env["EMAIL"] = github_user["email"]
 
-        c.Spawner.auth_state_hook = auth_state_hook
+        # c.Spawner.auth_state_hook = auth_state_hook
       default_url: |
         def default_url(request):
           if request.current_user and request.current_user.admin:
@@ -121,6 +147,56 @@ jupyterhub:
           return '/hub/spawn'
 
         c.JupyterHub.default_url = default_url
+      cilogon_groups: |
+        import json
+
+        with open("/etc/jupyterhub/access.json") as f:
+            access = json.load(f)
+
+        c.OAuthenticator.admin_users = set(access["admin_users"])
+        c.OAuthenticator.allowed_users = allowed_users = set(access["allowed_users"])
+
+        collab_groups = {}
+        for name, users in access["collaborations"].items():
+          collab_username = f"{name}@collaboration"
+          c.JupyterHub.load_roles.append({
+            "name": collab_username.replace("@", "-"),
+            "groups": [collab_username],
+            "scopes": [
+              "admin-ui",
+              f"list:users!user={collab_username}",
+              f"access:servers!user={collab_username}",
+              f"admin:servers!user={collab_username}",
+            ]
+          })
+          # define group membership while we're here
+          for username in users:
+            collab_groups.setdefault(username, []).append(collab_username)
+            # grant access to users in collaborations
+            # avoids need to duplicate listing in allowed_users
+            allowed_users.add(username)
+
+          allowed_users.add(f"{name}@collaboration")
+
+        from jupyterhub.app import JupyterHub
+
+        def collaboration_groups(auth_state):
+          # we only get auth state here, not username
+          # recompute username for group lookup
+          # FIXME: this should be easier??
+          authenticator = JupyterHub.instance().authenticator
+          username = authenticator.user_info_to_username(auth_state["cilogon_user"])
+          groups = collab_groups.get(username, [])
+          authenticator.log.info(f"Loading groups for {username}: {groups}")
+          return groups
+
+        c.CILogonOAuthenticator.auth_state_groups_key = collaboration_groups
+        c.OAuthenticator.manage_groups = True
+        print(c.OAuthenticator.allowed_users)
+    extraFiles:
+      access:
+        mountPath: /etc/jupyterhub/access.json
+        # data in config.enc.yaml
   singleuser:
     image:
       name: ghcr.io/bids/aifutureshub/user


### PR DESCRIPTION
allow login with ucb, ucdavis, ucsf, github

bids-access github org is no longer used, instead an `access.json` defines users and collaborations. Contents are encrypted, so user emails are not public