### PR TITLE
set a shorter default prompt in login shells

### DIFF
--- a/images/user/Dockerfile
+++ b/images/user/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update \
 ARG UID=1000
 RUN useradd -m -u 1000 jovyan
 COPY --from=build --chown=1000:1000 /srv/.pixi/envs/default /srv/.pixi/envs/default
-COPY mamba.sh /etc/profile.d/
+COPY mamba.sh prompt.sh /etc/profile.d/
 COPY entrypoint.sh /entrypoint.sh
 COPY mambarc /srv/.pixi/envs/default/.condarc
 

--- a/images/user/prompt.sh
+++ b/images/user/prompt.sh
@@ -1,0 +1,24 @@
+# a shorter default prompt for login shells (jupyterlab terminals, ssh)
+# debian's default is user@hostname, which is always jovyan on the pod name,
+# e.g. jovyan@jupyter-minrk-berkeley-edu---dc9ed9d1:~$
+#
+# sourced after mamba.sh, so this replaces the prompt env activation leaves.
+# `mamba activate` still adds its own `(env) ` prefix on top of it,
+# and a PS1 set in your own shell config still wins over this default.
+
+# these are bash prompt escapes, and only interactive shells have a prompt
+[ -n "${BASH_VERSION:-}" ] || return
+case $- in
+    *i*) ;;
+    *) return ;;
+esac
+
+case "${TERM:-dumb}" in
+    dumb)
+        PS1='\w \$ '
+        ;;
+    *)
+        # working directory in bold blue
+        PS1='\[\e[1;34m\]\w\[\e[0m\] \$ '
+        ;;
+esac


### PR DESCRIPTION
This PR proposes a shorter default shell prompt in the user image, so terminals show the working directory instead of `jovyan@<pod name>` (Fixes #20). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/214. You can sign in with your GitHub ID to claim ownership of the project.

## What changed and why

On a hub, Debian's stock `PS1` is the least useful prompt available: the user is always `jovyan` and the hostname is the pod name, so two thirds of the prompt is a constant plus a random string, and the working directory is pushed to the right. Reproduced on the currently published image (`org.opencontainers.image.revision` `9ea6ba6`, which is `images/` at `main`), with an empty home mounted over `/home/jovyan` the way the `home-nfs-mount` PVC does — note that with the NFS home in place there is no `~/.bashrc` from `/etc/skel`, so the prompt really does come from `/etc/bash.bashrc` and nothing later overrides it:

```console
$ docker run --rm --hostname jupyter-minrk-berkeley-edu---dc9ed9d1 \
    --tmpfs /home/jovyan:uid=1000,gid=1000 -e TERM=xterm-256color \
    ghcr.io/bids/aifutureshub/user:main bash -lic 'printf "%s\n" "${PS1@P}"'
(base) jovyan@jupyter-minrk-berkeley-edu---dc9ed9d1:~$
```

The change adds `images/user/prompt.sh` and copies it into `/etc/profile.d/` next to `mamba.sh`, which is the same mechanism the image already uses for login shells — and login shells are what users get: `entrypoint.sh` is `bash -l`, `jupyter_server_terminals` appends `-l` when the server's stdout is not a tty (the spawner case), and sshd sessions log in the same way. `run-parts` sources the directory in sorted order, so `prompt.sh` lands after `mamba.sh` and replaces the `PS1` that env activation leaves behind. The result is `~ $` with the directory in bold blue, falling back to an uncolored `\w \$ ` when `TERM` is `dumb` or unset.

Verified by applying the same `COPY mamba.sh prompt.sh /etc/profile.d/` line onto that published image and re-running the command above, plus the cases the file touches:

```console
after   -> ~ $                       # working directory, tracks cd (/srv -> "/srv $")
TERM=dumb              -> PS1=[\w \$ ]                  # no escapes for dumb terminals
mamba activate scratch -> (scratch) ~ $                 # mamba's own prefix still composes
mamba deactivate       -> (base) ~ $
bash -l (no -i)        -> PS1 untouched, jupyterhub-singleuser still resolves
sh -l                  -> unchanged from today's image
```

Two guards keep it out of the way of everything that is not a prompt: it returns immediately for non-interactive shells (so `entrypoint.sh` and `bash -lc ...` are untouched) and for non-bash shells, since these are bash's prompt escapes. It is a default, not a policy — `mamba activate` still adds its `(env) ` prefix on top, and a `PS1` set in your own shell config still wins. `pre-commit run --all-files` passes before and after this change, with the same set of hooks green; the file is mode 644 with no shebang, matching `mamba.sh`, so `check-executables-have-shebangs` stays happy. Your `Publish images` workflow builds `images/**` on pull requests, so the image itself gets built here too.

## How this was managed

We imported your issues and pull requests into a board — 39 stories and 3 labels — and used it to manage this work: the story for this change is [improve terminal prompt](https://eastagiletracker.com/projects/214/stories/79395), on the board at https://eastagiletracker.com/projects/214.

![board](https://raw.githubusercontent.com/eastagiletracker/hub-deploy/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
